### PR TITLE
added xpath selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A package to make it easier to scrape external web pages using laravel.
 * Support for scraping javascript rendered pages (Using https://github.com/amerkurev/scrapper)
 * Rotating user agents to avoid being blocked
 * Support for extracting data using CSS selectors
+* Support for extracting data using XPath expressions
 * Support for extracting data using dot notation from JSON responses
 * Support for extracting data using regular expressions
 * Caching responses to avoid repeated requests
@@ -30,6 +31,12 @@ $image = $scraper->getSelector('meta[property=og:image]|content')->first();
 
 // Get all paragraph innerHtml as an array
 $links = $scraper->getSelector('p')->all();
+
+// Get the first h1 element using XPath
+$h1 = $scraper->getXpath('//h1')->first();
+
+// Get the href attribute of the first link using XPath
+$linkHref = $scraper->getXpath('//a', 'attr', ['href'])->first();
  
  // Get values from the page via regex
 $author = $scraper->getRegex('~"user"\:"(.*)"~')->first();

--- a/src/WebScraperInterface.php
+++ b/src/WebScraperInterface.php
@@ -37,6 +37,8 @@ interface WebScraperInterface
 
     public function getSelector(string $selector, string|Closure $nodeContent = 'text', array $nodeContentArgs = []): Collection;
 
+    public function getXpath(string $xpath, string|Closure $nodeContent = 'text', array $nodeContentArgs = []): Collection;
+
     public function getJson(string $path): Collection;
 
     public function getRegex(string $regex): Collection;


### PR DESCRIPTION
This pull request adds support for extracting data using XPath expressions to the web scraping package. The most important changes include updates to the documentation, the addition of a new method to handle XPath, and the inclusion of corresponding unit tests.

### Documentation updates:
* Added support for extracting data using XPath expressions in the `README.md`.
* Provided examples of how to use the new XPath functionality in the `README.md`.

### Codebase updates:
* Added the `getXpath` method to the `src/AbstractWebScraper.php` file to enable data extraction using XPath expressions.
* Updated the `WebScraperInterface` to include the new `getXpath` method.

### Unit tests:
* Added unit tests for the new `getXpath` method to ensure it works correctly and handles various scenarios in the `src/tests/Unit/WebScraperTest.php` file.