### PR TITLE
add support for setting the cookie header

### DIFF
--- a/src/AbstractWebScraper.php
+++ b/src/AbstractWebScraper.php
@@ -31,6 +31,8 @@ abstract class AbstractWebScraper implements WebScraperInterface
 
     protected array $options = [];
 
+    protected string $cookies = '';
+
     protected array $errors = [];
 
     public function __construct()
@@ -49,12 +51,18 @@ abstract class AbstractWebScraper implements WebScraperInterface
 
     public function buildHeaders(): array
     {
-        return [
+        $headers = [
             'User-Agent' => $this->userAgentGenerator->generate(),
             'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
             'Accept-Language' => 'en-US,en;q=0.9',
             'Accept-Encoding' => 'gzip, deflate, br',
         ];
+
+        if ($this->cookies) {
+            $headers['Cookie'] = $this->cookies;
+        }
+
+        return $headers;
     }
 
     public function setOptions(array $options): self
@@ -79,6 +87,13 @@ abstract class AbstractWebScraper implements WebScraperInterface
     public function getUrl(): string
     {
         return $this->url;
+    }
+
+    public function setCookies(string $cookies): self
+    {
+        $this->cookies = $cookies;
+
+        return $this;
     }
 
     public function setUseCache(bool $useCache): self

--- a/src/WebScraperApi.php
+++ b/src/WebScraperApi.php
@@ -88,6 +88,10 @@ class WebScraperApi extends AbstractWebScraper
         $defaultParams = $this->defaultRequestParams;
         $defaultParams['timeout'] = $this->getRequestTimeout() * 1000; // Convert to milliseconds
 
+        if ($this->cookies) {
+            $defaultParams['extra-http-headers'] = "Cookie:{$this->cookies}";
+        }
+
         return array_merge(['url' => $this->url], $defaultParams, $this->getOptions());
     }
 }

--- a/src/WebScraperInterface.php
+++ b/src/WebScraperInterface.php
@@ -58,4 +58,6 @@ interface WebScraperInterface
     public function getBody(): string;
 
     public function setBody(string $body): self;
+
+    public function setCookies(string $cookies): self;
 }

--- a/src/tests/Unit/WebScraperApiTest.php
+++ b/src/tests/Unit/WebScraperApiTest.php
@@ -36,6 +36,26 @@ class WebScraperApiTest extends WebScraperTest
         $this->assertSame('test', $scraper->from('http://foo.bar')->get()->getBody());
     }
 
+    public function test_can_set_cookies()
+    {
+        $scraper = new WebScraperApi;
+        $cookies = 'cookie1=value1; cookie2=value2';
+        $scraper->setCookies($cookies);
+        $reqParams = $scraper->getRequestParams();
+        $this->assertArrayHasKey('extra-http-headers', $reqParams);
+        $this->assertSame($reqParams['extra-http-headers'], "Cookie:$cookies");
+    }
+
+    public function test_cookies_dont_override_extra_headers()
+    {
+        $scraper = new WebScraperApi;
+        $cookies = 'cookie1=value1; cookie2=value2';
+        $scraper->setOptions(['extra-http-headers' => 'X-Test-Header: test-value']);
+        $scraper->setCookies($cookies);
+        $reqParams = $scraper->getRequestParams();
+        $this->assertSame($reqParams['extra-http-headers'], 'X-Test-Header: test-value');
+    }
+
     protected function setupMocks(): void
     {
         Http::fake([

--- a/src/tests/Unit/WebScraperTest.php
+++ b/src/tests/Unit/WebScraperTest.php
@@ -53,6 +53,16 @@ class WebScraperTest extends TestCase
         $this->assertEquals('https://example.com', $scraper->getUrl());
     }
 
+    public function test_can_set_cookies()
+    {
+        $scraper = $this->getScraper();
+        $cookies = 'cookie1=value1; cookie2=value2';
+        $scraper->setCookies($cookies);
+        $headers = $scraper->buildHeaders();
+        $this->assertArrayHasKey('Cookie', $headers);
+        $this->assertSame($cookies, $headers['Cookie']);
+    }
+
     public function test_can_set_use_cache()
     {
         $scraper = $this->getScraper();


### PR DESCRIPTION
This pull request adds support for setting cookie header to the web scraping package for both, HTTP and API scrapers. This is useful for scraping pages that render different content depending on cookies set. For example, Amazon US will display prices in local currency, however it is possible to select desired currency using cookies.

## Codebase updates

- added protected `cookies` to the `src/AbstractWebScraper.php` file.
- added 'setCookies` method to the `src/WebScraperInterface.php` file.
- added public `setCookies` method to the `src/AbstractWebScraper.php` file for setting the cookie header.
- changed `buildHeaders` method in the `src/AbstractWebScraper.php` file to include `Cookie` header which enables HTTP scraper to include `Cookie` header in request.
- changed `getRequestParams` method in the  `src/WebScraperApi.php` file to include the `extra-http-headers` entry in params which enables API scraper to include `Cookie` header in request.

## Unit tests

- added a test to the `src/tests/Unit/WebScraperTest.php` file for testing if the `buildHeaders` method includes `Cookie` header.
- added a test to the `src/tests/Unit/WebScraperApiTest.php` file for testing if the `getRequestParams` method includes the `extra-http-headers` entry.
- added a test to the `src/tests/Unit/WebScraperApiTest.php` file for testing if the `getRequestParams` method prioritizes the `extra-http-headers` value from `setOptions` over `setCookies`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cookie support to web scraper requests. Users can now set cookies that will be automatically included in HTTP request headers.

* **Tests**
  * Added unit tests to validate cookie handling and ensure cookies are properly included in requests without overriding existing headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->